### PR TITLE
issue #68: Known good fix for twitch fullscreen.

### DIFF
--- a/scss/partials/_twitch-embed.scss
+++ b/scss/partials/_twitch-embed.scss
@@ -7,10 +7,7 @@
    margin: $gutter * 2 auto;
    max-width: 80rem;
    opacity: 0;
-   animation-delay: .6s;
-   animation-name: scale-in;
-   animation-duration: 1s;
-   animation-fill-mode: forwards;
+   
    @include medium-up {
       margin: 0 auto $gutter * 4;
       overflow: hidden;


### PR DESCRIPTION
This is the fix used during ESAW18 to allow the embedded Twitch player to go into fullscreen mode.

There might be a more optimal solution available that keeps the animations, but given that they seem rather brittle, it might be better to leave them out.