### PR TITLE
Forum link fix

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -63,7 +63,7 @@
                 <span>Twitch</span>
             </a>
 
-            <a href="http://www.speedrun.com/ESA_Winter_2018/forum" target="_blank" rel="noopener">
+            <a href="https://www.speedrun.com/esa2018/forum" target="_blank" rel="noopener">
                 <img src="/static/img/ico-forum.svg" alt="Forum icon">
                 <span>Forum</span>
             </a>


### PR DESCRIPTION
This fixes the forum link to go to the new forum at https://www.speedrun.com/esa2018/forum .
The old link went to the now archived Winter 2018 forum.

In the future, a method of setting this from the admin panel would be preferable, but for now, the events are infrequent enough for manual updates like this.