### PR TITLE
Make the footer not fixed

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -94,10 +94,12 @@ var cookieConsent = window.localStorage.getItem("cookie-consent")
 if (!cookieConsent) {
     // Get the footer
     var footer = document.querySelector('footer')
-    // Append warning to footer
-    footer.innerHTML = '<p class="cookie-warning"><strong>This page utilizes cookies to ensure you get the best experience on our website <span class="small button">Ok!</span><strong></p>' + footer.innerHTML
-    // Get the warning element
-    var cookieWarning = document.querySelector('.cookie-warning')
+    // Create cookie warning element
+    var cookieWarning = document.createElement('div')
+    cookieWarning.className += 'cookie-warning'
+    cookieWarning.innerHTML = '<p><strong>This page utilizes cookies to ensure you get the best experience on our website <span class="small button">Ok!</span><strong></p>'
+    // Insert the warning before the footer element
+    footer.parentNode.insertBefore(cookieWarning, footer)
     // Add an eventlistener to the button
     cookieWarning.querySelector('.button').addEventListener('click', function () {
         // On click we store the consent

--- a/scss/partials/_footer.scss
+++ b/scss/partials/_footer.scss
@@ -1,3 +1,15 @@
+.cookie-warning {
+   z-index: 5;
+   position: fixed;
+   position: sticky;
+   bottom: 0;
+   left: 0;
+   width: 100%;
+   text-align: center;
+   background: $blue-darker;
+   padding: $gutter;
+}
+
 footer {
    background: $blue-darker;
    color: $white;

--- a/scss/partials/_footer.scss
+++ b/scss/partials/_footer.scss
@@ -6,10 +6,6 @@ footer {
    text-align: center;
    font-size: .8rem;
    padding: $gutter;
-   position: fixed;
-   bottom: 0;
-   left: 0;
-   width: 100%;
 
    .menu {
       list-style: none;


### PR DESCRIPTION
I believe that the footer does not contain information used frequently enough to deserve to be always fixed to the bottom of the users screen.

This PR makes the footer stuck to the bottom of the page instead of the screen and moves the cookie consent dialog to its own element fixed to the bottom of the screen as it was previously contained within the footer.

(This PR was only ran manually. I did not run the website as I don't have the required Go environment. That said it should run just fine, unless the SCSS processor does weird stuff.)